### PR TITLE
Added rotation 

### DIFF
--- a/merge/Scenes/Levels/main.tscn
+++ b/merge/Scenes/Levels/main.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=7 format=4 uid="uid://d2h4yf8j5d665"]
 
 [ext_resource type="PackedScene" uid="uid://xt236ukuaf8g" path="res://Scenes/Player/player_alt.tscn" id="4_nk5xi"]
-[ext_resource type="Texture2D" uid="uid://des1omiae8kyu" path="res://Assets/Level Designs/Ground_tiles_base.png" id="5_5sf7f"]
+[ext_resource type="Texture2D" uid="uid://bq7d8a3h48p1r" path="res://Assets/Level Designs/Ground_tiles_base.png" id="5_5sf7f"]
 [ext_resource type="PackedScene" uid="uid://da7urblf8fisc" path="res://Scenes/Enemy/enemy.tscn" id="6_w0lsm"]
 [ext_resource type="PackedScene" uid="uid://bqaa7rsmwq6nj" path="res://Scenes/EnemyFlyingBat/enemy_flying_bat.tscn" id="7_tpkgp"]
 

--- a/merge/Scenes/Player/Body Part Scenes/Arms/test_arm.gd
+++ b/merge/Scenes/Player/Body Part Scenes/Arms/test_arm.gd
@@ -3,7 +3,7 @@ extends Node2D
 @export var animation_tree : AnimationTree
 var playback: AnimationNodeStateMachinePlayback
 var attack_state : bool = false
-
+var original_rotation = rotation
 @onready var anim = $AnimationPlayer
 
 func _ready() -> void:
@@ -12,6 +12,12 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed("attack"):
+		var angle_to_turn : float = get_local_mouse_position().angle()
+		if rad_to_deg(angle_to_turn) > 75:
+			angle_to_turn = deg_to_rad(75)
+		elif rad_to_deg(angle_to_turn) < -75:
+			angle_to_turn = deg_to_rad(-75)
+		$Rotation.rotation = angle_to_turn
 		attack_state = true
 		
 	select_animation()
@@ -23,6 +29,7 @@ func select_animation():
 		await get_tree().create_timer(0.5).timeout
 		attack_state = false
 	else:
+		$Rotation.rotation = original_rotation
 		playback.travel("idle")
 		
 func update_animation_parameters():

--- a/merge/Scenes/Player/Body Part Scenes/Arms/test_arm.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/Arms/test_arm.tscn
@@ -6,6 +6,27 @@
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_44rg6"]
 size = Vector2(39.9167, 16.6667)
 
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_82sb8"]
+animation = &"attack"
+
+[sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_fli2t"]
+blend_point_0/node = SubResource("AnimationNodeAnimation_82sb8")
+blend_point_0/pos = 0.0
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_44rg6"]
+animation = &"idle"
+
+[sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_82sb8"]
+blend_point_0/node = SubResource("AnimationNodeAnimation_44rg6")
+blend_point_0/pos = 0.0
+blend_mode = 1
+
+[sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_qoqoo"]
+states/attack/node = SubResource("AnimationNodeBlendSpace1D_fli2t")
+states/attack/position = Vector2(653, 100)
+states/idle/node = SubResource("AnimationNodeBlendSpace1D_82sb8")
+states/idle/position = Vector2(424, 105)
+
 [sub_resource type="Animation" id="Animation_dg762"]
 length = 0.001
 tracks/0/type = "value"
@@ -157,56 +178,38 @@ _data = {
 &"idle": SubResource("Animation_44rg6")
 }
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_82sb8"]
-animation = &"attack"
-
-[sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_fli2t"]
-blend_point_0/node = SubResource("AnimationNodeAnimation_82sb8")
-blend_point_0/pos = 0.0
-
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_44rg6"]
-animation = &"idle"
-
-[sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_82sb8"]
-blend_point_0/node = SubResource("AnimationNodeAnimation_44rg6")
-blend_point_0/pos = 0.0
-blend_mode = 1
-
-[sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_qoqoo"]
-states/attack/node = SubResource("AnimationNodeBlendSpace1D_fli2t")
-states/attack/position = Vector2(653, 100)
-states/idle/node = SubResource("AnimationNodeBlendSpace1D_82sb8")
-states/idle/position = Vector2(424, 105)
-
 [node name="TestArm" type="Node2D" node_paths=PackedStringArray("animation_tree")]
 scale = Vector2(2, 2)
 script = ExtResource("1_pysri")
 animation_tree = NodePath("AnimationTree")
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-root_node = NodePath("../Sprite2D")
-libraries = {
-&"": SubResource("AnimationLibrary_oa8rm")
-}
+[node name="Rotation" type="Node2D" parent="."]
+position = Vector2(-11, -19)
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="Sprite2D" type="Sprite2D" parent="Rotation"]
 texture_filter = 1
-position = Vector2(7, -9.5)
+position = Vector2(18, 9.5)
 scale = Vector2(1.5, 1.5)
 texture = ExtResource("2_mcd8l")
 hframes = 2
 vframes = 3
 
-[node name="Area2D" type="Area2D" parent="Sprite2D"]
+[node name="Area2D" type="Area2D" parent="Rotation/Sprite2D"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Sprite2D/Area2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Rotation/Sprite2D/Area2D"]
 position = Vector2(9.33333, -6.33333)
 shape = SubResource("RectangleShape2D_44rg6")
 disabled = true
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-root_node = NodePath("../Sprite2D")
+root_node = NodePath("../Rotation/Sprite2D")
 tree_root = SubResource("AnimationNodeStateMachine_qoqoo")
 anim_player = NodePath("../AnimationPlayer")
 parameters/attack/blend_position = 0.00149477
 parameters/idle/blend_position = 0
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+root_node = NodePath("../Rotation/Sprite2D")
+libraries = {
+&"": SubResource("AnimationLibrary_oa8rm")
+}

--- a/merge/Scenes/Player/Body Part Scenes/Arms/test_arm.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/Arms/test_arm.tscn
@@ -1,10 +1,7 @@
 [gd_scene load_steps=13 format=3 uid="uid://bfony667xs5jm"]
 
 [ext_resource type="Script" uid="uid://fo4kt5vth2k7" path="res://Scenes/Player/Body Part Scenes/Arms/test_arm.gd" id="1_pysri"]
-[ext_resource type="Texture2D" uid="uid://cdkov0kwwno7c" path="res://Assets/CharacterPNGs/Attack/arm attack - no fluff.png" id="2_mcd8l"]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_44rg6"]
-size = Vector2(39.9167, 16.6667)
+[ext_resource type="Texture2D" uid="uid://cjgni2pl2r2wi" path="res://Assets/CharacterPNGs/Attack/arm attack - no fluff.png" id="2_mcd8l"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_44rg6"]
 size = Vector2(39.9167, 16.6667)

--- a/merge/Scenes/Player/Body Part Scenes/RigArms/RigLeftArm.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigArms/RigLeftArm.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=16 format=3 uid="uid://be4nn4uuu1qgo"]
 
 [ext_resource type="Script" uid="uid://dav17cuhpickm" path="res://Scenes/Player/Body Part Scenes/RigArms/toechondria_arm.gd" id="1_cp83w"]
-[ext_resource type="Texture2D" uid="uid://b7fnalwp46fr7" path="res://Assets/CharacterPNGs/Body Parts/Arms/Right Arms/toechondria_right_arm_spritesheet.png" id="2_cp83w"]
+[ext_resource type="Texture2D" uid="uid://40c5yk4gg8iw" path="res://Assets/CharacterPNGs/Body Parts/Arms/Right Arms/toechondria_right_arm_spritesheet.png" id="2_cp83w"]
 
 [sub_resource type="Animation" id="Animation_xnnka"]
 length = 0.001

--- a/merge/Scenes/Player/Body Part Scenes/RigArms/RigLeftArm.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigArms/RigLeftArm.tscn
@@ -8,7 +8,7 @@ length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:animation")
+tracks/0/path = NodePath("Rotation/Sprite:animation")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -20,7 +20,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("Sprite:frame")
+tracks/1/path = NodePath("Rotation/Sprite:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -36,7 +36,7 @@ length = 0.5
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -53,7 +53,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -70,7 +70,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -87,7 +87,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -141,12 +141,6 @@ states/movement/position = Vector2(401, 127)
 script = ExtResource("1_cp83w")
 animation_tree = NodePath("AnimationTree")
 
-[node name="Sprite" type="Sprite2D" parent="."]
-scale = Vector2(4, 4)
-texture = ExtResource("2_cp83w")
-hframes = 9
-vframes = 3
-
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
 &"": SubResource("AnimationLibrary_5gvrm")
@@ -158,5 +152,15 @@ anim_player = NodePath("../AnimationPlayer")
 parameters/attack/blend_position = 0
 parameters/movement/blend_position = 0
 
-[node name="BulletStartPosition" type="Marker2D" parent="."]
-position = Vector2(42, -37)
+[node name="Rotation" type="Node2D" parent="."]
+position = Vector2(-38, -63)
+
+[node name="Sprite" type="Sprite2D" parent="Rotation"]
+position = Vector2(38, 63)
+scale = Vector2(4, 4)
+texture = ExtResource("2_cp83w")
+hframes = 9
+vframes = 3
+
+[node name="BulletStartPosition" type="Marker2D" parent="Rotation"]
+position = Vector2(80, 26)

--- a/merge/Scenes/Player/Body Part Scenes/RigArms/RigRightArm.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigArms/RigRightArm.tscn
@@ -8,7 +8,7 @@ length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:animation")
+tracks/0/path = NodePath("Rotation/Sprite:animation")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -20,7 +20,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("Sprite:frame")
+tracks/1/path = NodePath("Rotation/Sprite:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -37,7 +37,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -54,7 +54,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -71,7 +71,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -88,7 +88,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite:frame")
+tracks/0/path = NodePath("Rotation/Sprite:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -138,12 +138,6 @@ states/movement/position = Vector2(356, 109)
 script = ExtResource("1_bpp0d")
 animation_tree = NodePath("AnimationTree")
 
-[node name="Sprite" type="Sprite2D" parent="."]
-scale = Vector2(4, 4)
-texture = ExtResource("2_bpp0d")
-hframes = 9
-vframes = 3
-
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
 &"": SubResource("AnimationLibrary_5gvrm")
@@ -154,7 +148,17 @@ tree_root = SubResource("AnimationNodeStateMachine_hk8mb")
 anim_player = NodePath("../AnimationPlayer")
 parameters/movement/blend_position = 0
 
-[node name="BulletStartPosition" type="Marker2D" parent="."]
-position = Vector2(44, -57)
+[node name="Rotation" type="Node2D" parent="."]
+position = Vector2(-39, -63)
+
+[node name="Sprite" type="Sprite2D" parent="Rotation"]
+position = Vector2(39, 63)
+scale = Vector2(4, 4)
+texture = ExtResource("2_bpp0d")
+hframes = 9
+vframes = 3
+
+[node name="BulletStartPosition" type="Marker2D" parent="Rotation"]
+position = Vector2(83, 6)
 
 [connection signal="shoot" from="." to="." method="_on_shoot"]

--- a/merge/Scenes/Player/Body Part Scenes/RigArms/RigRightArm.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigArms/RigRightArm.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=15 format=3 uid="uid://bdbqxexxodb32"]
 
 [ext_resource type="Script" uid="uid://dav17cuhpickm" path="res://Scenes/Player/Body Part Scenes/RigArms/toechondria_arm.gd" id="1_bpp0d"]
-[ext_resource type="Texture2D" uid="uid://b7fnalwp46fr7" path="res://Assets/CharacterPNGs/Body Parts/Arms/Right Arms/toechondria_right_arm_spritesheet.png" id="2_bpp0d"]
+[ext_resource type="Texture2D" uid="uid://40c5yk4gg8iw" path="res://Assets/CharacterPNGs/Body Parts/Arms/Right Arms/toechondria_right_arm_spritesheet.png" id="2_bpp0d"]
 
 [sub_resource type="Animation" id="Animation_s6vtg"]
 length = 0.001

--- a/merge/Scenes/Player/Body Part Scenes/RigArms/toechondria_arm.gd
+++ b/merge/Scenes/Player/Body Part Scenes/RigArms/toechondria_arm.gd
@@ -50,5 +50,5 @@ func _on_shoot(pos: Variant, direction: Variant) -> void:
 	var bullet = bullet_scene.instantiate()
 	bullet.global_position = bullet_marker.global_position
 	bullet.scale.x = direction
-	bullet.direction = direction
+	bullet.direction = (get_global_mouse_position() - bullet_marker.global_position).normalized()
 	get_tree().current_scene.add_child(bullet)

--- a/merge/Scenes/Player/Body Part Scenes/RigArms/toechondria_arm.gd
+++ b/merge/Scenes/Player/Body Part Scenes/RigArms/toechondria_arm.gd
@@ -8,9 +8,11 @@ signal shoot(pos, direction)
 var bullet_marker : Marker2D
 var bullet_scene : PackedScene = preload("res://Scenes/Projectiles/toechondria_bullet.tscn")
 
+var angle_to_turn_limit : float = deg_to_rad(75)
+
 func _ready() -> void:
 	playback = animation_tree["parameters/playback"]
-	bullet_marker = $BulletStartPosition
+	bullet_marker = $Rotation/BulletStartPosition
 	# Disable looping on the jump animation
 	var anim_player = get_node("AnimationPlayer")
 	if anim_player.has_animation("jump"):
@@ -37,18 +39,25 @@ func update_animation(is_in_air: bool, direction: float):
 func trigger_attack():
 	if not attack_state:
 		attack_state = true
+		var angle_to_turn : float = get_local_mouse_position().angle()
+		if angle_to_turn > angle_to_turn_limit:
+			angle_to_turn = angle_to_turn_limit
+		elif angle_to_turn < -angle_to_turn_limit:
+			angle_to_turn = -angle_to_turn_limit
+			
+		$Rotation.rotation = angle_to_turn
 		# The arm is a child of a slot, which is a child of the Positioning node whose scale is flipped.
 		var facing_direction = 1 if get_parent().get_parent().scale.x > 0 else -1
-		shoot.emit(bullet_marker.position, facing_direction)
+		shoot.emit(angle_to_turn, facing_direction)
 		playback.travel("attack")
 		# Timer to reset attack state
 		await get_tree().create_timer(0.5).timeout
 		attack_state = false
-
-func _on_shoot(pos: Variant, direction: Variant) -> void:
+	$Rotation.rotation = rotation
+func _on_shoot(angle_to_turn: float, direction: Variant) -> void:
 	await get_tree().create_timer(0.2).timeout
 	var bullet = bullet_scene.instantiate()
 	bullet.global_position = bullet_marker.global_position
 	bullet.scale.x = direction
-	bullet.direction = (get_global_mouse_position() - bullet_marker.global_position).normalized()
+	bullet.direction = Vector2.RIGHT.rotated(angle_to_turn)
 	get_tree().current_scene.add_child(bullet)

--- a/merge/Scenes/Player/Body Part Scenes/RigHead/RigHead.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigHead/RigHead.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=7 format=3 uid="uid://dm2dnot7xhj2p"]
 
-[ext_resource type="Texture2D" uid="uid://r51lpcje04bk" path="res://Assets/CharacterPNGs/Body Parts/Head/toechondria_head_spritesheet.png" id="1_va3vb"]
+[ext_resource type="Texture2D" uid="uid://rvtq8nrc8g4f" path="res://Assets/CharacterPNGs/Body Parts/Head/toechondria_head_spritesheet.png" id="1_va3vb"]
 
 [sub_resource type="Animation" id="Animation_2ems0"]
 length = 0.001

--- a/merge/Scenes/Player/Body Part Scenes/RigLegs/RigLeftLeg.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigLegs/RigLeftLeg.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=13 format=3 uid="uid://de1wo850vs1xe"]
 
 [ext_resource type="Script" uid="uid://ck28elgc71p3s" path="res://Scenes/Player/Body Part Scenes/RigLegs/rig_left_leg.gd" id="1_qrifa"]
-[ext_resource type="Texture2D" uid="uid://0bcro22qnilk" path="res://Assets/CharacterPNGs/Body Parts/Legs/toechondria_left_leg_spritesheet.png" id="1_xdc2s"]
+[ext_resource type="Texture2D" uid="uid://htirpcvh6pvj" path="res://Assets/CharacterPNGs/Body Parts/Legs/toechondria_left_leg_spritesheet.png" id="1_xdc2s"]
 
 [sub_resource type="Animation" id="Animation_r34lo"]
 length = 0.001

--- a/merge/Scenes/Player/Body Part Scenes/RigLegs/RigRightLeg.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigLegs/RigRightLeg.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=13 format=3 uid="uid://b24mlhsofie3h"]
 
 [ext_resource type="Script" uid="uid://fjchm0wm4h5y" path="res://Scenes/Player/Body Part Scenes/RigLegs/rig_right_leg.gd" id="1_1fpij"]
-[ext_resource type="Texture2D" uid="uid://c5j0lrbu7m4ff" path="res://Assets/CharacterPNGs/Body Parts/Legs/toechondria_right_leg_spritesheet.png" id="1_88iti"]
+[ext_resource type="Texture2D" uid="uid://dk4sjvif7nl24" path="res://Assets/CharacterPNGs/Body Parts/Legs/toechondria_right_leg_spritesheet.png" id="1_88iti"]
 
 [sub_resource type="Animation" id="Animation_1fpij"]
 length = 0.001

--- a/merge/Scenes/Player/Body Part Scenes/RigTorso/RigTorso.tscn
+++ b/merge/Scenes/Player/Body Part Scenes/RigTorso/RigTorso.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=7 format=3 uid="uid://7mvuqltagalc"]
 
-[ext_resource type="Texture2D" uid="uid://uab3m8htffd8" path="res://Assets/CharacterPNGs/Body Parts/Torso/toechondria_torso_spritesheet.png" id="2_pw54b"]
+[ext_resource type="Texture2D" uid="uid://dis5ye645bobe" path="res://Assets/CharacterPNGs/Body Parts/Torso/toechondria_torso_spritesheet.png" id="2_pw54b"]
 
 [sub_resource type="Animation" id="Animation_abidk"]
 length = 0.001

--- a/merge/Scenes/Projectiles/toechondria_bullet.gd
+++ b/merge/Scenes/Projectiles/toechondria_bullet.gd
@@ -1,13 +1,14 @@
 extends Area2D
 
 @export var speed : int = 1000
-var direction 
+var direction : Vector2
 
 func _ready() -> void:
 	var player : CharacterBody2D = get_tree().get_first_node_in_group("player")
 	scale = player.scale
+	rotation = direction.angle()
 
 
 func _process(delta):
-	position.x += direction * speed * delta
+	position += direction * speed * delta
  

--- a/merge/Scenes/Projectiles/toechondria_bullet.tscn
+++ b/merge/Scenes/Projectiles/toechondria_bullet.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://b7dtq48mdvg8p"]
 
-[ext_resource type="Script" uid="uid://b2ohckwyh2qq2" path="res://toechondria_bullet.gd" id="1_ffs03"]
-[ext_resource type="Texture2D" uid="uid://bw5dvaf2acdf1" path="res://Scenes/Player/Body Part Scenes/Bullets/toechondria_bullet.png" id="2_o8p02"]
+[ext_resource type="Script" uid="uid://b2ohckwyh2qq2" path="res://Scenes/Projectiles/toechondria_bullet.gd" id="1_ffs03"]
+[ext_resource type="Texture2D" uid="uid://xlv715gt4g54" path="res://Scenes/Player/Body Part Scenes/Bullets/toechondria_bullet.png" id="2_o8p02"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_g3lvi"]
 radius = 25.02


### PR DESCRIPTION
- Toechondria Bullet sprite will rotate depending on the angle at which it's shot.
- Toechondria Arm will rotate based on the direction of the mouse when attack is pressed and get reset after animation is over.
- Melee Arm also rotates based on the direction of mouse
- All arms, and the bullet has rotation limit to avoid jank -- Can be changed later